### PR TITLE
Feat/limit dragons

### DIFF
--- a/backend/app/api/dragon.js
+++ b/backend/app/api/dragon.js
@@ -18,7 +18,7 @@ router.get("/new", (req, res, next) => {
     accountId = account.id;
 
     // Get a new dragon instance from the generation engine
-    dragon = req.app.locals.engine.generation.newDragon();
+    dragon = req.app.locals.engine.generation.newDragon({ accountId });
 
     // Store the new dragon in the database
     return DragonTable.storeDragon(dragon);

--- a/backend/app/generation/index.js
+++ b/backend/app/generation/index.js
@@ -6,7 +6,7 @@ const refreshRate = REFRESH_RATE * SECONDS;
 
 class Generation {
   constructor() {
-
+    this.accountIds = new Set();
     this.expiration = this.calculateExpiration();
     this.generationId = undefined;
 
@@ -26,11 +26,18 @@ class Generation {
 
   }
 
-  newDragon() {
+  newDragon({ accountId}) {
 
     if (Date.now() > this.expiration) {
       throw new Error(`This generation expired on ${this.expiration}`);
     }
+
+    if (this.accountIds.has(accountId)) {
+      throw new Error("You already have a dragon from this generation!");
+    }
+
+    this.accountIds.add(accountId);
+
     return new Dragon({generationId: this.generationId});
   }
 }

--- a/frontend/src/components/Dragon.js
+++ b/frontend/src/components/Dragon.js
@@ -11,6 +11,7 @@ const Dragon = () => {
   const { data: dragon, error, isLoading, refetch } = useFetchDragonQuery();
   const selectedDragon = useSelector((state) => state.dragon.selectedDragon);
 
+  // Dispatch the dragon data to the Redux store if dragon data is available
   useEffect(() => {
     if (dragon) {
       dispatch(selectDragon(dragon));
@@ -21,15 +22,20 @@ const Dragon = () => {
     refetch();
   };
 
-  console.log("Dragon in parent component:", dragon);
-
   if (isLoading) return <Loader />;
-  if (error) return <div>Error: {error.message}</div>;
 
   return (
     <div>
       <h3>This is a Dragon</h3>
-      {selectedDragon && <DragonAvatar dragon={selectedDragon.dragon} />}
+      {/* Loader while fetching */}
+      {isLoading && <Loader />}
+
+      {/* Either show error or DragonAvatar, but not both */}
+      {!isLoading && error ? (
+        <div>Error: {error.data?.message || "An error occurred"}</div>
+      ) : (
+        selectedDragon && <DragonAvatar dragon={selectedDragon.dragon} />
+      )}
       <Button onClick={handleCreateDragon}>New Dragon!</Button>
     </div>
   );

--- a/frontend/src/components/Dragon.js
+++ b/frontend/src/components/Dragon.js
@@ -32,7 +32,7 @@ const Dragon = () => {
 
       {/* Either show error or DragonAvatar, but not both */}
       {!isLoading && error ? (
-        <div>Error: {error.data?.message || "An error occurred"}</div>
+        <h2>Error: {error.data?.message || "An error occurred"}</h2>
       ) : (
         selectedDragon && <DragonAvatar dragon={selectedDragon.dragon} />
       )}


### PR DESCRIPTION
## Description

This update focuses on improving the generation logic to prevent the creation of duplicate dragons and enhances the `Dragon` component to handle loading and error states more effectively when fetching dragon data.

## Type of Changes

- **New Features:**
  - Refactored the `Dragon` component to handle loading and error states when fetching dragon data. The component now shows a loader while data is being fetched and an error message if an error occurs. If the fetch is successful, the dragon data is dispatched to the Redux store.

- **Fixes & Updates:**
  - Updated the `newDragon` method in the `Generation` class to prevent duplicate dragons for the same account within a generation. The logic now checks if the `accountId` already has a dragon from that generation. If it does, an error is thrown, ensuring that each account can only have one dragon per generation.  
    _Fixes issue #123_

## Testing Steps / QA Criteria

### How to Run the Application

#### Frontend

1. **Navigate to the frontend directory:**
    ```bash
    cd frontend
    ```
2. **Install dependencies:**
    ```bash
    npm install
    ```
3. **Start the frontend development server:**
    ```bash
    npm run dev
    ```

#### Backend

1. **Navigate to the backend directory:**
    ```bash
    cd backend
    ```
2. **Install dependencies:**
    ```bash
    npm install
    ```
3. **Start the backend development server:**
    ```bash
    npm run dev
    ```

### Testing the Dragon Component

- Ensure that the `Dragon` component displays a loader while fetching dragon data.
- Verify that an error message appears if there is an issue with the data fetch.
- Confirm that, upon successful fetch, the dragon data is dispatched to the Redux store.

### Testing the Generation Logic

- Try creating multiple dragons for the same account within the same generation. The application should throw an error, preventing the creation of duplicate dragons for that account.

## Updates
### "After" Screenshots

![image](https://github.com/user-attachments/assets/af5b2ee9-295f-4421-ad07-a3590980c863)

![image](https://github.com/user-attachments/assets/ead99a15-76ff-453d-b525-159a2e16010a)
